### PR TITLE
password generator version 4-patch

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,6 +11,8 @@
     <properties>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     </properties>
 
     <build>
@@ -29,9 +31,14 @@
                 </configuration>
             </plugin>
             <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>exec-maven-plugin</artifactId>
-                <version>3.1.0</version>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.11.0</version>
+                <configuration>
+                    <source>17</source>
+                    <target>17</target>
+                    <encoding>UTF-8</encoding>
+                </configuration>
             </plugin>
         </plugins>
     </build>
@@ -42,6 +49,16 @@
             <build>
                 <finalName>password-generator-Console</finalName>
                 <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-compiler-plugin</artifactId>
+                        <version>3.11.0</version>
+                        <configuration>
+                            <source>17</source>
+                            <target>17</target>
+                            <encoding>UTF-8</encoding>
+                        </configuration>
+                    </plugin>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-jar-plugin</artifactId>


### PR DESCRIPTION
This pull request updates the Maven configuration in `pom.xml` to improve build consistency and ensure proper encoding settings. The most important changes include setting UTF-8 encoding properties and updating the compiler plugin configuration.

Build and encoding configuration improvements:

* Added `project.build.sourceEncoding` and `project.reporting.outputEncoding` properties to set UTF-8 encoding for source files and reporting output.
* Replaced the `exec-maven-plugin` with the `maven-compiler-plugin`, specifying Java 17 as the source and target version and setting the encoding to UTF-8.

Compiler plugin updates:

* Added a new `maven-compiler-plugin` configuration under the inner `<build>` section to ensure consistent compilation settings for the project, including Java version and UTF-8 encoding.